### PR TITLE
Add typescript types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Generated typescript files
+src/wallet_address_validator.[dj]*
+src/currencies.[dj]*
+
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -267,8 +267,10 @@
     "url": "https://github.com/Swyftx/crypto-address-validator.git"
   },
   "main": "src/wallet_address_validator",
+  "types": "src/wallet_address_validator.d.ts",
   "scripts": {
     "bundle": "browserify src/wallet_address_validator.js --standalone WAValidator --outfile dist/wallet-address-validator.js",
+    "build-ts": "tsc --declaration src/wallet_address_validator.ts src/currencies.ts",
     "minify": "uglifyjs -c -m -o dist/wallet-address-validator.min.js -- dist/wallet-address-validator.js",
     "test:node": "mocha test",
     "test:browser": "echo Temp bypass until jenkins setup",
@@ -292,6 +294,7 @@
     "rfc4648": "^1.3.0"
   },
   "devDependencies": {
+    "@types/node": "^14.0.27",
     "browserify": "^15.1.0",
     "chai": "^4.1.2",
     "eslint-config-standard": "^13.0.1",
@@ -303,6 +306,7 @@
     "node-gzip": "^1.1.2",
     "prettysize": "^2.0.0",
     "standard": "^12.0.1",
+    "typescript": "^3.9.7",
     "uglify-es": "^3.3.10"
   },
   "standard": {

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -28,8 +28,23 @@ const ALGOValidator = require('./algo_validator')
 const BCHValidator = require('./bitcoincash_validator')
 const SYSValidator = require('./sys_validator')
 
+export type Currencies = Array<{
+    name: string,
+    symbol: string,
+    validator: {
+      // `currency` must be `any` to avoid recureferences
+      isValidAddress:(address:string, currency:any, networkType:string, addressFormats:string[])=>boolean,
+      verifyChecksum:(address:string)=>boolean
+    },
+    addressTypes?: { prod: string[], testnet?: string[] },
+    iAddressTypes?:{ prod: string[], testnet?: string[] },
+    expectedLength?: number,
+    hashFunction?: string,
+    regex?: RegExp,
+  }> 
+
 // defines P2PKH and P2SH address types for standard (prod) and testnet networks
-const CURRENCIES = [{
+const CURRENCIES:Currencies = [{
   name: 'Algorand',
   symbol: 'algo',
   validator: ALGOValidator

--- a/src/wallet_address_validator.ts
+++ b/src/wallet_address_validator.ts
@@ -1,4 +1,5 @@
 var currencies = require('./currencies')
+import {Currencies} from './currencies'
 
 var DEFAULT_CURRENCY_NAME = 'bitcoin'
 
@@ -13,7 +14,7 @@ module.exports = {
    * @param {Array} addressFormats Array of formats. For example ['legacy', 'slp ', 'cash']
    * @returns {Error|Boolean}
    */
-  validate: function (address, currencyNameOrSymbol, networkType, addressFormats) {
+  validate: function (address:string, currencyNameOrSymbol:string, networkType?:string, addressFormats?:string[]):boolean {
     var currency = currencies.getByNameOrSymbol(currencyNameOrSymbol || DEFAULT_CURRENCY_NAME)
 
     if (currency && currency.validator) {
@@ -28,5 +29,5 @@ module.exports = {
     throw new Error('Missing validator for currency: ' + currencyNameOrSymbol)
   },
 
-  CURRENCIES: currencies.CURRENCIES
+  CURRENCIES: currencies.CURRENCIES as Currencies
 }


### PR DESCRIPTION
This PR adds typescript types to the public API. I tried to be the least invasive possible with the current code and setup (without sacrificing type checking) so I simply converted some files into typescript and made typescript emit the declaration files.

The only changes to the build process will be:
- When building the code, `npm run build-ts` will need to be run in order to generate currencies.js and wallet_address_validator.js
- These two .js files should be treated as simple build artifacts, all new code changes should be applied to the `.ts` files instead.