### PR TITLE
Improve Cardano validator with Shelley format

### DIFF
--- a/src/cardano_validator.js
+++ b/src/cardano_validator.js
@@ -1,6 +1,7 @@
 var cbor = require('cbor-js')
 var CRC = require('crc')
 var base58 = require('./crypto/base58')
+var bech32 = require('./crypto/bech32')
 
 function getDecoded (address) {
   try {
@@ -12,9 +13,8 @@ function getDecoded (address) {
   }
 }
 
-module.exports = {
-  isValidAddress: function (address) {
-    var decoded = getDecoded(address)
+function isByron(address) {
+  var decoded = getDecoded(address)
 
     if (!decoded || (!Array.isArray(decoded) && decoded.length !== 2)) {
       return false
@@ -30,5 +30,15 @@ module.exports = {
     var crc = CRC.crc32(tagged)
 
     return crc === validCrc
+}
+
+function isShelley(address) {
+  var decoded = bech32.decode(address)
+  return decoded !== null
+}
+
+module.exports = {
+  isValidAddress: function (address) {
+    return isByron(address) || isShelley(address)
   }
 }

--- a/src/crypto/bech32.js
+++ b/src/crypto/bech32.js
@@ -96,7 +96,7 @@ function decode (bechString) {
   }
   bechString = bechString.toLowerCase()
   var pos = bechString.lastIndexOf('1')
-  if (pos < 1 || pos + 7 > bechString.length || bechString.length > 90) {
+  if (pos < 1 || pos + 7 > bechString.length) {
     return null
   }
   var hrp = bechString.substring(0, pos)

--- a/test/wallet_address_validator.js
+++ b/test/wallet_address_validator.js
@@ -546,6 +546,15 @@ describe('WAValidator.validate()', function () {
       valid('0x48337b8dd78a9761a73d0fbb8f5c8a0ddda32d85', 'eng')
       valid('0xda816e2122a8a39b0926bfa84edd3d42477e9efd', 'eng')
     })
+
+    it('should return true for correct ADA addresses', () => {
+      valid('addr1sjck9mdmfyhzvjhydcjllgj9vjvl522w0573ncustrrr2rg7h9azg4cyqd36yyd48t5ut72hgld0fg2xfvz82xgwh7wal6g2xt8n996s3xvu5g', 'ada')
+      valid('addr1qxkyhslnaw9w34qu7h7ulhhxtrms5hjgfez6g6mmy7tre6g46as4mxxqzarsjfhef8gpcx64mmdt0ae9dhmacclhvepqrl7j7j', 'ada')
+      valid('addr1vypr00ss7hkqejmvh53xkyf0p9q0a4z2uprxmx6njc463vgst3pe4', 'ada')
+      valid('addr1qx6nj63rslzt9s8f6n97r5yszhhz0yvhemehehfrpa6ywkzfvwnyln6dkahl4ju7a42qsvxg9ke5qrl4xma56swpz35q86w42j', 'ada')
+      valid('Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi', 'ada')
+      valid('37btjrVyb4KEB2STADSsj3MYSAdj52X5FrFWpw2r7Wmj2GDzXjFRsHWuZqrw7zSkwopv8Ci3VWeg6bisU9dgJxW5hb2MZYeduNKbQJrqz3zVBsu9nT', 'ada')
+    })
   })
 
   describe('invalid results', function () {
@@ -855,6 +864,12 @@ describe('WAValidator.validate()', function () {
       invalid('1MZZNZS5cPQu8THtpqcTF3bQASBQoWr6zo', 'sys')
       // invalid('sys1qzpuka2847ecyf62xw0996v7wh2ehkdaegf6annn', 'sys')
       invalid('dsfasys1qzpuka2847ecyf62xw0996v7wh2ehkdaegf6annn', 'sys')
+    })
+    it('should return false for incorrect ADA Addresses', () => {
+      invalid('1EQUz46mFC5Wa4hbmfp7pzJa3tzNLWxyfr', 'ada')
+      invalid('0xda816e2122a8a39b0926bfa84edd3d42477e9efE', 'ada')
+      invalid('38ty1qB68gHsiyZ8k3RPeCJ1wYQPrUCPPr', 'ada')
+      invalid('addr1nervermindsjck9mdmfyhzvjhydcjllgj9vjvl522w0573ncustrrr2rg7h9azg4cyqd36yyd48t5ut72hgld0fg2xfvz82xgwh7wal6g2xt8n996s3xvu5g', 'ada')
     })
   })
 })


### PR DESCRIPTION
Hi @GusGold,

this PR:

- [x] Improves Cardano validator with Shelley format
- [x] Removes limit of 90 characters when using bech32
- [x] Adds valid and invalid tests

Shelley format is used since 2020. The validator needs to support both Byron (legacy) and Shelley format.

As Cardano often uses longer addresses than 90 characters, I remove the limit in bech32.js.